### PR TITLE
fixed rails 3.2 bug with FileNotFound

### DIFF
--- a/lib/less/rails/import_processor.rb
+++ b/lib/less/rails/import_processor.rb
@@ -12,7 +12,7 @@ module Less
         import_paths.each do |path|
           pathname = begin
                        context.resolve(path)
-                     rescue FileNotFound
+                     rescue Sprockets::FileNotFound
                        nil
                      end
           context.depend_on(path) if pathname && pathname.to_s.ends_with?('.less')


### PR DESCRIPTION
When I run `ber assets:precompile:primary` in an app updated to rails 3.2 I get `uninitialized constant Less::Rails::ImportProcessor::FileNotFound`. I fixed it with this change.
