### PR TITLE
upgrade to therubyracer 0.10.x call semantics

### DIFF
--- a/less-rails.gemspec
+++ b/less-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_runtime_dependency 'less', '~> 2.0.7'
+  s.add_runtime_dependency 'less', '~> 2.1.0'
   s.add_runtime_dependency 'actionpack', '~> 3.1.1'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'guard-minitest'

--- a/lib/less/rails/helpers.rb
+++ b/lib/less/rails/helpers.rb
@@ -6,7 +6,7 @@ module Less
   
   def self.register_rails_helper(name, &block)
     tree = @loader.require('less/tree')
-    tree.functions[name] = lambda do |node|
+    tree.functions[name] = lambda do |this, node|
       tree[:Anonymous].new block.call(tree, node)
     end
   end


### PR DESCRIPTION
In JavaScript, every function call has a `this`
context. In prior versions of therubyracer and
therubyrhino, this context was simply dropped on 
the floor and only the arguments were passed to
ruby procs.

This has been corrected, and now every embedded
lambda or proc receives the `this` object as its
first parameter.

This commit upgrades to that interface for all
rails helpers.
