### PR TITLE
Fixed an error when used with Edge Rails.

### DIFF
--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -20,7 +20,7 @@ module Less
       
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
         raise 'The less-rails plugin requires the asset pipeline to be enabled.' unless app.config.assets.enabled
-        app.assets.register_preprocessor 'text/css', ImportProcessor
+        (Sprockets.respond_to?('register_preprocessor') ? Sprockets : app.assets).register_preprocessor 'text/css', ImportProcessor
       end
       
       initializer 'less-rails.after.load_config_initializers', :after => :load_config_initializers, :group => :all do |app|


### PR DESCRIPTION
With current sprockets with Edge Rails, I got an error pasted below:

The error was raised because of `app.assets` at [the line](https://github.com/metaskills/less-rails/blob/master/lib/less/rails/railtie.rb#L23), which is an instance of `Sprockets::Index` and it always rails when `register_preprocessor()` called.

less-rails now works fine with Rails 3.x, but it'll fail when Rails 4 is released. So I've made a workaround for that problem, which dosn't break compatibility, I think.

```
/Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/sprockets-36edf5e3e83c/lib/sprockets/index.rb:81:in `expire_index!': can't modify immutable index (TypeError)
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/sprockets-36edf5e3e83c/lib/sprockets/base.rb:175:in `register_preprocessor'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/gems/less-rails-2.2.3/lib/less/rails/railtie.rb:23:in `block in <class:Railtie>'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rails-fc32ff4ee322/railties/lib/rails/initializable.rb:30:in `instance_exec'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rails-fc32ff4ee322/railties/lib/rails/initializable.rb:30:in `run'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rails-fc32ff4ee322/railties/lib/rails/initializable.rb:55:in `block in run_initializers'
        from /Users/usr0600239/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/tsort.rb:150:in `block in tsort_each'
        from /Users/usr0600239/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/tsort.rb:183:in `block (2 levels) in each_strongly_connected_component'
        from /Users/usr0600239/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/tsort.rb:219:in `each_strongly_connected_component_from'
        from /Users/usr0600239/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/tsort.rb:182:in `block in each_strongly_connected_component'
        from /Users/usr0600239/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/tsort.rb:180:in `each'
        from /Users/usr0600239/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/tsort.rb:180:in `each_strongly_connected_component'
        from /Users/usr0600239/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/tsort.rb:148:in `tsort_each'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rails-fc32ff4ee322/railties/lib/rails/initializable.rb:54:in `run_initializers'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rails-fc32ff4ee322/railties/lib/rails/application.rb:185:in `initialize!'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rails-fc32ff4ee322/railties/lib/rails/railtie/configurable.rb:30:in `method_missing'
        from /Users/usr0600239/dev/github/hyperion/config/environment.rb:5:in `<top (required)>'
        from /Users/usr0600239/dev/github/hyperion/spec/spec_helper.rb:2:in `require'
        from /Users/usr0600239/dev/github/hyperion/spec/spec_helper.rb:2:in `<top (required)>'
        from /Users/usr0600239/dev/github/hyperion/spec/requests/host_spec.rb:1:in `require'
        from /Users/usr0600239/dev/github/hyperion/spec/requests/host_spec.rb:1:in `<top (required)>'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rspec-core-5d28318b51bf/lib/rspec/core/configuration.rb:784:in `load'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rspec-core-5d28318b51bf/lib/rspec/core/configuration.rb:784:in `block in load_spec_files'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rspec-core-5d28318b51bf/lib/rspec/core/configuration.rb:784:in `each'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rspec-core-5d28318b51bf/lib/rspec/core/configuration.rb:784:in `load_spec_files'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rspec-core-5d28318b51bf/lib/rspec/core/command_line.rb:22:in `run'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rspec-core-5d28318b51bf/lib/rspec/core/runner.rb:69:in `run'
        from /Users/usr0600239/dev/github/hyperion/vendor/bundle/ruby/1.9.1/bundler/gems/rspec-core-5d28318b51bf/lib/rspec/core/runner.rb:8:in `block in autorun'
```
