### PR TITLE
Rails 4 compatibility

### DIFF
--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -19,7 +19,9 @@ module Less
       end
       
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
-        raise 'The less-rails plugin requires the asset pipeline to be enabled.' unless app.config.assets.enabled
+        if ::Rails::VERSION::MAJOR < 4
+          raise 'The less-rails plugin requires the asset pipeline to be enabled.' unless app.config.assets.enabled
+        end
         (Sprockets.respond_to?('register_preprocessor') ? Sprockets : app.assets).register_preprocessor 'text/css', ImportProcessor
       end
       


### PR DESCRIPTION
config.assets.enabled is deprecated in Rails 4
