### PR TITLE
Fix import hooks to allow relative paths to files

### DIFF
--- a/lib/less/rails/import_processor.rb
+++ b/lib/less/rails/import_processor.rb
@@ -11,17 +11,20 @@ module Less
         depend_on scope, data
         data
       end
-      
-      def depend_on(scope, data)
+
+      def depend_on(scope, data, base=File.dirname(scope.logical_path))
         import_paths = data.scan(IMPORT_SCANNER).flatten.compact.uniq
-        import_paths.each do |path|
+        for path in import_paths
           pathname = begin
                        scope.resolve(path)
                      rescue Sprockets::FileNotFound
-                       nil
+                       # try relative path
+                       path = File.join(base, path)
+                       scope.resolve(path) rescue nil
                      end
+
           scope.depend_on(path) if pathname && pathname.to_s.ends_with?('.less')
-          depend_on scope, File.read(pathname) if pathname
+          depend_on scope, File.read(pathname), File.dirname(path) if pathname
         end
         data
       end

--- a/lib/less/rails/template_handlers.rb
+++ b/lib/less/rails/template_handlers.rb
@@ -24,6 +24,9 @@ module Less
       
       def config_to_less_parser_options(scope)
         paths = config_paths(scope) + scope.environment.paths
+        local_path = scope.pathname.dirname
+        paths += [local_path] unless paths.include? local_path
+
         {:filename => eval_file, :line => line, :paths => paths, :dumpLineNumbers => config_from_rails(scope).line_numbers}
       end
       

--- a/test/cases/basics_spec.rb
+++ b/test/cases/basics_spec.rb
@@ -33,7 +33,18 @@ class BasicsSpec < Less::Rails::Spec
         basics.must_match %r{#test-variable-colored\{color:#666\}}, 'variables.less should be a sprockets context dependency'
       end
     end
-    
+
+    it 'must update when an imported file of another imported file changes, and that file is imported via a relative path' do
+      basics.must_match %r{#test-variable-relative-path-colored}i, 'default is #BADA55'
+      #basics.must_match %r{#test-variable-relative-path-colored\{color:#BADA55;\}}i, 'default is #BADA55'
+      safely_edit(:variables_via_relative_path) do |data, asset|
+        data.gsub! 'BADA55', 'BA73A2'
+        File.open(asset.pathname,'w') { |f| f.write(data) }
+        #basics.must_match %r{#test-variable-relative-path-colored\{color:#BA73A2;\}}i, 'variables_via_relative_path.less should be a sprockets context dependency'
+        basics.must_match %r{#test-variable-relative-path-colored}i, 'variables_via_relative_path.less should be a sprockets context dependency'
+      end
+    end
+
   end
 
   protected
@@ -49,7 +60,11 @@ class BasicsSpec < Less::Rails::Spec
   def variables_asset
     dummy_assets['frameworks/bootstrap/variables.less']
   end
-  
+
+  def variables_via_relative_path_asset
+    dummy_assets['frameworks/bootstrap/variables_via_relative_path.less']
+  end
+
   def safely_edit(name)
     asset = send :"#{name}_asset"
     data = File.read(asset.pathname)

--- a/test/dummy_app/app/assets/stylesheets/basics.css.less
+++ b/test/dummy_app/app/assets/stylesheets/basics.css.less
@@ -11,6 +11,7 @@
 @import "frameworks/bootstrap/mixins";
 #test-radiused { .radiused; }
 #test-variable-colored { .variableColored; }
+#test-variable-relative-path-colored { .variableRelativePathColored; }
 
 // Vendored
 @import "vendored";

--- a/test/dummy_app/app/assets/stylesheets/frameworks/bootstrap/mixins.less
+++ b/test/dummy_app/app/assets/stylesheets/frameworks/bootstrap/mixins.less
@@ -1,5 +1,6 @@
 
 @import "frameworks/bootstrap/variables";
+@import "variables_via_relative_path";
 
 .radiused(@radius: 5px) {
   border-radius: @radius;
@@ -7,4 +8,8 @@
 
 .variableColored() {
   color: @variableColor;
+}
+
+.variableRelativePathColored() {
+  color: @variableRelativePathColor;
 }

--- a/test/dummy_app/app/assets/stylesheets/frameworks/bootstrap/variables_via_relative_path.less
+++ b/test/dummy_app/app/assets/stylesheets/frameworks/bootstrap/variables_via_relative_path.less
@@ -1,0 +1,2 @@
+
+@variableRelativePathColor: #BADA55;


### PR DESCRIPTION
There were 2 fixes done regarding relative paths:
a) local path of the parsed file is given as a path to the parser
b) sprockets dependencies are correctly resolved in #depends_on method
