### PR TITLE
Add the ability to depend_on another less file without having that file be included in the output.

### DIFF
--- a/test/cases/basics_spec.rb
+++ b/test/cases/basics_spec.rb
@@ -13,6 +13,18 @@ class BasicsSpec < Less::Rails::Spec
   it 'must be able to use vendored less files' do
     basics.must_match %r{#test-vendored\{border-radius:10px;\}}
   end
+
+  describe 'depends_on' do
+
+    it 'must be able to use a vendor dependency file' do
+      basics.must_match %r{#class-using-vendor-variable\{color:white;\}}
+    end
+
+    it 'must not include the vendor dependency file in the output' do
+      basics.must_not match %r{\.vendorClass\{color:white;\}}
+    end
+
+  end
   
   describe 'less import dependency hooks' do
     

--- a/test/dummy_app/app/assets/stylesheets/basics.css.less
+++ b/test/dummy_app/app/assets/stylesheets/basics.css.less
@@ -1,3 +1,7 @@
+@depend_on "vendor_dependency"
+.class-using-vendor-variable {
+  color: @vendorVariable;
+}
 
 // Variables
 @color: #4D926F;

--- a/test/dummy_app/vendor/assets/stylesheets/vendor_dependency.less
+++ b/test/dummy_app/vendor/assets/stylesheets/vendor_dependency.less
@@ -1,0 +1,5 @@
+@vendorVariable: white;
+
+.vendorClass {
+  color: @vendorVariable;
+}


### PR DESCRIPTION
This is a failing test case for the ability to depend on a less file but not have that less file be included in the output.

See [this issue](https://github.com/metaskills/less-rails/issues/66) and [this gist](https://gist.github.com/mikesnare/6487815).
