### PR TITLE
Upgrade to less 2.5 and be less restrictive about the version

### DIFF
--- a/less-rails.gemspec
+++ b/less-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
-  gem.add_runtime_dependency 'less', '~> 2.4.0'
+  gem.add_runtime_dependency 'less', '~> 2.5'
   gem.add_runtime_dependency 'actionpack', '>= 3.1'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'minitest'


### PR DESCRIPTION
I updated the `less` dependency to version 2.5 and at the same time restricted it only to the major version instead of the minor version, because a new minor release should be backwards compatible and it will allow people to upgrade to a newer less version without having to release a new version of this gem.

I am using this version in my project as a git dependency and everything still works as well as all test cases are succeeding.

Mentioning #83: If you really need this urgently, put

``` ruby
gem "less-rails", git: "git@github.com:CQQL/less-rails.git", branch: "less-2.5"
```

in your Gemfile.
