### PR TITLE
Fix dropped import dependencies

### DIFF
--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -19,7 +19,9 @@ module Less
       end
 
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
-        (Sprockets.respond_to?('register_preprocessor') ? Sprockets : app.assets).register_preprocessor 'text/css', ImportProcessor
+        app.assets.register_preprocessor 'text/css', ImportProcessor
+        Sprockets.register_preprocessor 'text/css', ImportProcessor if Sprockets.respond_to?('register_preprocessor')
+
         app.assets.context_class.extend(LessContext)
         app.assets.context_class.less_config = app.config.less
       end


### PR DESCRIPTION
Not sure if the `Sprockets.register_preprocessor` line still needs to be there, but apparently while Sprockets does respond to register_preprocessor, Rails 4.1 at least requires you register the processor on `app.assets`, not on `Sprockets`, else the ImportProcessor just isn't called and any `@import` dependencies are never added.

Fixes my bug #87 and probably #80 too.
