### PR TITLE
Fix Undefined MethodError at app.assets.register_preprocessor for sprockets3

### DIFF
--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -16,8 +16,8 @@ module Less
       end
 
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
-        app.assets.register_preprocessor 'text/css', ImportProcessor
-        Sprockets.register_preprocessor 'text/css', ImportProcessor if Sprockets.respond_to?('register_preprocessor')
+        sprockets_env = app.assets || Sprockets
+        sprockets_env.register_preprocessor 'text/css', ImportProcessor
 
         config.assets.configure do |env|
           env.context_class.class_eval do

--- a/test/cases/helpers_spec.rb
+++ b/test/cases/helpers_spec.rb
@@ -7,10 +7,11 @@ class HelpersSpec < Less::Rails::Spec
   let(:helpers) { dummy_asset('helpers') }
   
   it 'parse asset paths' do
-    line_for_helper('asset-path').must_equal  'asset-path: "/assets/rails.png";'
-    line_for_helper('asset-url').must_equal   "asset-url: url(/assets/rails.png);"
-    line_for_helper('image-path').must_equal  'image-path: "/assets/rails.png";'
-    line_for_helper('image-url').must_equal   "image-url: url(/assets/rails.png);"
+    _digest = Rails.application.assets['rails.png'].digest
+    line_for_helper('asset-path').must_equal  "asset-path: \"/assets/rails-#{_digest}.png\";"
+    line_for_helper('asset-url').must_equal   "asset-url: url(/assets/rails-#{_digest}.png);"
+    line_for_helper('image-path').must_equal  "image-path: \"/assets/rails-#{_digest}.png\";"
+    line_for_helper('image-url').must_equal   "image-url: url(/assets/rails-#{_digest}.png);"
     line_for_helper('video-path').must_equal  'video-path: "/videos/rails.mp4";'
     line_for_helper('video-url').must_equal   "video-url: url(/videos/rails.mp4);"
     line_for_helper('audio-path').must_equal  'audio-path: "/audios/rails.mp3";'

--- a/test/dummy_app/init.rb
+++ b/test/dummy_app/init.rb
@@ -14,6 +14,7 @@ module Dummy
     config.eager_load = false
     
     config.assets.enabled = true if ::Rails::VERSION::MAJOR < 4
+    config.assets.digest = true
     config.assets.cache_store = [:file_store, "#{config.root}/tmp/cache/assets/"]
     
   end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -54,7 +54,7 @@ module Less
         dummy_config.assets.version = version
         dummy_assets.version = version
         cache = dummy_assets.cache
-        cache.respond_to?(:clear) ? cache.clear : rm_r("#{dummy_tmp}/cache/assets")
+        cache.respond_to?(:clear) ? cache.clear : rm_rf("#{dummy_tmp}/cache/assets")
       end
       
       def prepare_cache_dir


### PR DESCRIPTION
With  Rails 4.2.5, I got an error below ( at `rails c` and `rails s`).

```
/Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/less-rails-2.7.0/lib/less/rails/railtie.rb:19:in `block in <class:Railtie>': undefined method `register_preprocessor' for nil:NilClass (NoMethodError)
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/initializable.rb:30:in `instance_exec'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/initializable.rb:30:in `run'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/initializable.rb:55:in `block in run_initializers'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:345:in `each'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:345:in `call'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/initializable.rb:54:in `run_initializers'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/application.rb:352:in `initialize!'
	from /Users/suzuken/Documents/suzan2go/nasulog/config/environment.rb:5:in `<top (required)>'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/application.rb:328:in `require'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/application.rb:328:in `require_environment!'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:142:in `require_application_and_environment!'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:67:in `console'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from /Users/suzuken/Documents/suzan2go/nasulog/vendor/bundle/ruby/2.2.0/gems/railties-4.2.5/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```

I think this is because sprockets 3.X, `app.assets` is assigned in after_initialize callback .
https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb#L164

related #106 #111
