### PR TITLE
Sprockets compatibility. Fix `env` undefined.

### DIFF
--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -1,6 +1,6 @@
 require 'sprockets/railtie'
 
-module Less  
+module Less
   module Rails
     class Railtie < ::Rails::Railtie
       config.less = ActiveSupport::OrderedOptions.new
@@ -15,9 +15,11 @@ module Less
         Sprockets::Engines #force autoloading
 
         if Sprockets.respond_to?(:register_engine)
-          args = ['.less', LessTemplate]
-          args << { mime_type: 'text/less', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
-          env.register_engine(*args)
+          config.assets.configure do |env|
+            args = ['.less', LessTemplate]
+            args << { mime_type: 'text/less', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+            env.register_engine(*args)
+          end
         end
       end
 
@@ -37,12 +39,11 @@ module Less
         assets_stylesheet_paths = app.config.assets.paths.select { |p| p && p.to_s.ends_with?('stylesheets') }
         app.config.less.paths.unshift(*assets_stylesheet_paths)
       end
-      
+
       initializer 'less-rails.setup_compression', :group => :all do |app|
         config.less.compress = app.config.assets.compress
       end
-      
+
     end
   end
 end
-


### PR DESCRIPTION
Fix problem:
```/Users/ildar/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/railtie.rb:195:in `method_missing': undefined local variable or method `env' for Less::Rails::Railtie:Class
Did you mean?  Nenv (NameError)
       	from /Users/ildar/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/less-rails-063a189f83d4/lib/less/rails/railtie.rb:20:in `block in <class:Railtie>'```