### PR TITLE
Rails5 - fix for first deprecation warning see issue #122

### DIFF
--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -14,19 +14,20 @@ module Less
         require 'less-rails'
         Sprockets::Engines #force autoloading
 
-        if Sprockets.respond_to?(:register_engine)
-          args = ['.less', LessTemplate]
-          args << { mime_type: 'text/less', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
-          Sprockets.register_engine(*args)
-        elsif Sprockets.respond_to?(:register_transformer)
-          Sprockets.register_mime_type 'text/less', extensions: ['.less'], charset: :css
-          Sprockets.register_preprocessor 'text/less', ImportProcessor
-        end
+        config.assets.configure do |env|
+          if env.respond_to?(:register_engine)
+            args = ['.less', LessTemplate]
+            args << { mime_type: 'text/less', silence_deprecation: true } if env::VERSION.start_with?("3")
+            env.register_engine(*args)
+          elsif env.respond_to?(:register_transformer)
+            env.register_mime_type 'text/less', extensions: ['.less'], charset: :css
+            env.register_preprocessor 'text/less', ImportProcessor
+          end
+        end 
       end
 
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
         sprockets_env = app.assets || Sprockets
-        sprockets_env.register_mime_type 'text/less', extensions: ['.less'], charset: :css
         sprockets_env.register_preprocessor 'text/css', ImportProcessor
 
         config.assets.configure do |env|

--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -18,6 +18,9 @@ module Less
           args = ['.less', LessTemplate]
           args << { mime_type: 'text/less', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
           Sprockets.register_engine(*args)
+        elsif Sprockets.respond_to?(:register_transformer)
+          Sprockets.register_mime_type 'text/less', extensions: ['.less'], charset: :css
+          Sprockets.register_preprocessor 'text/less', ImportProcessor
         end
       end
 

--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -26,6 +26,7 @@ module Less
 
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
         sprockets_env = app.assets || Sprockets
+        sprockets_env.register_mime_type 'text/less', extensions: ['.less'], charset: :css
         sprockets_env.register_preprocessor 'text/css', ImportProcessor
 
         config.assets.configure do |env|

--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -17,7 +17,7 @@ module Less
         if Sprockets.respond_to?(:register_engine)
           args = ['.less', LessTemplate]
           args << { mime_type: 'text/less', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
-          env.register_engine(*args)
+          Sprockets.register_engine(*args)
         end
       end
 

--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -17,7 +17,7 @@ module Less
         config.assets.configure do |env|
           if env.respond_to?(:register_engine)
             args = ['.less', LessTemplate]
-            args << { mime_type: 'text/less', silence_deprecation: true } if env::VERSION.start_with?("3")
+            args << { mime_type: 'text/less', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
             env.register_engine(*args)
           elsif env.respond_to?(:register_transformer)
             env.register_mime_type 'text/less', extensions: ['.less'], charset: :css


### PR DESCRIPTION
this fix resolves the first deprecation warning object of issue #122 

second warning persists...
i've tested this using rails 4.2.4
pls check against rails5 ...

regards, 
francesco
