### PR TITLE
[fix #122] Avoid Sprockets deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.4
-  - jruby-19mode
+language: ruby
+cache: bundler
+sudo: false
 before_install:
-  - travis_retry gem install bundler
-  - bundle --version
-install:
-  - travis_retry bundle install
-before_script:
-  - travis_retry bundle exec appraisal install
+  - gem install bundler -v 1.13.7
 script:
-  - bundle exec appraisal rake test
+  - bundle exec rake test
+rvm:
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
+env:
+  - "RAILS_VERSION=4.0"
+  - "RAILS_VERSION=4.1"
+  - "RAILS_VERSION=4.2"
+  - "RAILS_VERSION=5.0"
+matrix:
+  exclude:
+    - rvm: 2.1.9
+      env: "RAILS_VERSION=5.0"

--- a/Appraisals
+++ b/Appraisals
@@ -2,10 +2,22 @@ appraise 'rails40' do
   gem 'rails', '~> 4.0.11'
 end
 
-appraise 'rails41' do
-  gem 'rails', '~> 4.1.7'
+appraise "rails-4-1" do
+	gem 'rails', '~> 4.1.16'
+  gem "activerecord", "~> 4.1.16"
 end
 
-appraise 'rails42' do
-  gem 'rails', '~> 4.2.1'
+appraise "rails-4-2" do
+	gem 'rails', '~> 4.2.7'
+  gem "activerecord", "~> 4.2.7"
+end
+
+appraise "rails-5-0" do
+  gem 'rails', '~> 5.0.0'
+  gem "activerecord", "~> 5.0.0"
+end
+
+appraise "rails-5-1" do
+  gem 'rails', '~> 5.1.0.beta1'
+  gem "activerecord", "~> 5.1.0.beta1"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### 2.8.1 - 2016-11-11
+
+* Avoid Sprockets deprecations
+	Fixes https://github.com/metaskills/less-rails/issues/122
+
 ### 2.8.0 - ?
 
 * Make it possible to pass parameters to less.rb

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 gem "therubyracer", "~> 0.12.0", :require => nil, :platforms => :ruby
 gem "therubyrhino", "~> 2.0.2", :require => nil, :platforms => :jruby
 
-gem "mime-types", "~> 2.6.2", :platforms => [:ruby_19, :jruby]
+gem "mime-types"
+gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This gem provides integration for Rails projects using the Less stylesheet langu
 Just bundle up less-rails in your Gemfile. This will pull in less as a runtime dependency too.
 
 ```ruby
-gem 'less-rails', '~> 2.7.0'
+gem 'less-rails', '~> 2.8.1'
 ```
 
 But be warned, less.rb relies on a JavaScript runtime gem too. Just like ExecJS, it will look for a gem that is appropriate to your system. Typically, this means you will need one of the following.

--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -13,14 +13,23 @@ module Less
         require 'less'
         require 'less-rails'
         Sprockets::Engines #force autoloading
-        Sprockets.register_engine '.less', LessTemplate
       end
 
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
         sprockets_env = app.assets || Sprockets
-        sprockets_env.register_preprocessor 'text/css', ImportProcessor
 
         config.assets.configure do |env|
+          if env.respond_to?(:register_transformer)
+            env.register_mime_type 'text/less', extensions: ['.less'], charset: :css
+            env.register_transformer 'text/less', 'text/css', ImportProcessor
+          end
+
+          if env.respond_to?(:register_engine)
+            args = ['.less', LessTemplate]
+            args << {mime_type: 'text/less', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+            env.register_engine(*args)
+          end
+
           env.context_class.class_eval do
             class_attribute :less_config
             self.less_config = app.config.less

--- a/lib/less/rails/version.rb
+++ b/lib/less/rails/version.rb
@@ -1,5 +1,5 @@
 module Less
   module Rails
-    VERSION = "2.8.0"
+    VERSION = "2.8.1"
   end
 end


### PR DESCRIPTION
- Use both 'register_engine' and 'register_transformer' in railtie.rb