### PR TITLE
adds silence_deprecation flag as true for suppresing warnings

### DIFF
--- a/lib/less/rails/railtie.rb
+++ b/lib/less/rails/railtie.rb
@@ -28,7 +28,7 @@ module Less
 
       initializer 'less-rails.before.load_config_initializers', :before => :load_config_initializers, :group => :all do |app|
         sprockets_env = app.assets || Sprockets
-        sprockets_env.register_preprocessor 'text/css', ImportProcessor
+        sprockets_env.register_preprocessor 'text/css', ImportProcessor, silence_deprecation: true
 
         config.assets.configure do |env|
           env.context_class.class_eval do

--- a/lib/less/rails/version.rb
+++ b/lib/less/rails/version.rb
@@ -1,5 +1,5 @@
 module Less
   module Rails
-    VERSION = "2.8.0"
+    VERSION = "2.8.1"
   end
 end


### PR DESCRIPTION
hi,
after adding the `silence_deprecation` flag as `true`, the annoying warning message won't appear anymore.

I know that's not a good solution but, it can be used until the problem is solved.